### PR TITLE
fix: fixed tls hostname

### DIFF
--- a/k8s/clusters/cluster-0/manifests/core/monitoring/thanos/helm-release.yaml
+++ b/k8s/clusters/cluster-0/manifests/core/monitoring/thanos/helm-release.yaml
@@ -39,7 +39,7 @@ spec:
             cert-manager.io/cluster-issuer: letsencrypt-production
           tls:
             - hosts:
-                - "zigbee.${SECRET_DOMAIN}"
+                - "thanos.${SECRET_DOMAIN}"
               secretName: thanos-cert
     queryFrontend:
       enabled: false


### PR DESCRIPTION
tls hostname was set to `zigbee`.  Probably a bad copy and paste 😆 